### PR TITLE
Only link chapters with full URLs

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-const re = RegExp('^(http|https)://');
+const re = RegExp('^https?://');
 
 document.addEventListener('DOMContentLoaded', () => {
     const fileInput = document.getElementById('file-input');
@@ -222,7 +222,7 @@ function showMangaDetails(manga, categories) {
 
             const chapterLink = document.createElement('a');
             chapterLink.textContent = chapter.name;
-            if (chapter.url.startsWith("htt")) {
+            if (chapter.url.match(re)) {
                 chapterLink.href = chapter.url;
                 chapterLink.target = '_blank';
             }

--- a/script.js
+++ b/script.js
@@ -221,9 +221,11 @@ function showMangaDetails(manga, categories) {
             chapterBox.className = 'chapter-box';
 
             const chapterLink = document.createElement('a');
-            chapterLink.href = chapter.url;
             chapterLink.textContent = chapter.name;
-            chapterLink.target = '_blank';
+            if (chapter.url.startsWith("htt")) {
+                chapterLink.href = chapter.url;
+                chapterLink.target = '_blank';
+            }
             if (chapter.read) {
                 chapterLink.classList.add('read');
             }


### PR DESCRIPTION
Adding relative URLs is pretty much pointless as they won't lead anywhere.
Unless there was a way to manually specify `baseUrls` for each source ID to prefix those relative and make them full URLs, that's the best (least confusing) alternative.