### PR TITLE
Trim displayed library titles

### DIFF
--- a/scripts/library.js
+++ b/scripts/library.js
@@ -111,16 +111,27 @@ export function initializeLibrary() {
         const tabContent = document.getElementById(category.name);
 
         const titleFull = manga.customTitle || manga.title;
-        const titleTrimmed = titleFull.length > 30 ? titleFull.substring(0, 35) + '…' : titleFull;
+        const titleTrimmed = titleFull.length > 35 ? titleFull.substring(0, 35) + '…' : titleFull;
         const mangaItem = document.createElement('div');
         mangaItem.className = 'manga-item';
-        mangaItem.title = titleFull;
+        var title = `Chapters: ${manga.chapters?.length}`;
+        title += ` | Read: ${manga.chapters?.filter(c => c.read).length}`;
+        if (manga.dateAdded) title += `\nAdded: ${parseDate(manga.dateAdded)}`;
+        if (manga.history)
+          title += `\nLast Read: ${parseDate(
+            Math.max.apply(
+              0,
+              manga.history.map(h => parseInt(h.lastRead || '0'))
+            )
+          )}`;
+        mangaItem.title = title;
         const cover = document.createElement('img');
         cover.src = manga.customThumbnailUrl || manga.thumbnailUrl;
         cover.loading = 'lazy';
         cover.alt = '';
         const entryTitle = document.createElement('p');
         entryTitle.innerText = titleTrimmed;
+        entryTitle.classList.add('manga-item-title');
         mangaItem.appendChild(cover);
         mangaItem.appendChild(entryTitle);
         mangaItem.addEventListener('click', () => {
@@ -130,14 +141,14 @@ export function initializeLibrary() {
             window.data.backupSources.find(source => source.sourceId === manga.source).name
           );
         });
-        mangaItem.addEventListener(
-          'mouseenter',
-          event => (event.target.querySelector('p').innerText = titleFull)
-        );
-        mangaItem.addEventListener(
-          'mouseleave',
-          event => (event.target.querySelector('p').innerText = titleTrimmed)
-        );
+        mangaItem.addEventListener('mouseenter', event => {
+          entryTitle.innerText = titleFull;
+          entryTitle.classList.add('full-title');
+        });
+        mangaItem.addEventListener('mouseleave', event => {
+          entryTitle.innerText = titleTrimmed;
+          entryTitle.classList.remove('full-title');
+        });
         tabContent.appendChild(mangaItem);
       });
     });
@@ -346,8 +357,7 @@ function showMangaDetails(manga, categories, source) {
       if (Array.isArray(manga.history)) {
         const historyItem = manga.history.find(history => history.url === chapter.url);
         if (historyItem) {
-          const date = new Date(parseInt(historyItem.lastRead));
-          lastReadDate.textContent = `${date.toLocaleString()}`;
+          lastReadDate.textContent = parseDate(historyItem.lastRead);
         }
       }
 
@@ -360,6 +370,11 @@ function showMangaDetails(manga, categories, source) {
   showModal('manga-modal');
   const mangaModalContent = document.querySelector('#manga-modal .modal-content');
   mangaModalContent.scrollTop = 0;
+}
+
+export function parseDate(timestamp) {
+  const date = new Date(parseInt(timestamp));
+  return date.toLocaleString();
 }
 
 export function toggleExpandDescription() {

--- a/scripts/library.js
+++ b/scripts/library.js
@@ -110,13 +110,19 @@ export function initializeLibrary() {
         const category = categories.find(cat => cat.order === catOrder) || { name: 'Default' };
         const tabContent = document.getElementById(category.name);
 
+        const titleFull = manga.customTitle || manga.title;
+        const titleTrimmed = titleFull.length > 30 ? titleFull.substring(0, 35) + '…' : titleFull;
         const mangaItem = document.createElement('div');
         mangaItem.className = 'manga-item';
-        mangaItem.innerHTML = `
-                <img src="${
-                  manga.customThumbnailUrl || manga.thumbnailUrl
-                }" loading="lazy" title="${manga.customTitle || manga.title}" alt="">
-                <p>${manga.customTitle || manga.title}</p>`;
+        mangaItem.title = titleFull;
+        const cover = document.createElement('img');
+        cover.src = manga.customThumbnailUrl || manga.thumbnailUrl;
+        cover.loading = 'lazy';
+        cover.alt = '';
+        const entryTitle = document.createElement('p');
+        entryTitle.innerText = titleTrimmed;
+        mangaItem.appendChild(cover);
+        mangaItem.appendChild(entryTitle);
         mangaItem.addEventListener('click', () => {
           showMangaDetails(
             manga,
@@ -124,6 +130,14 @@ export function initializeLibrary() {
             window.data.backupSources.find(source => source.sourceId === manga.source).name
           );
         });
+        mangaItem.addEventListener(
+          'mouseenter',
+          event => (event.target.querySelector('p').innerText = titleFull)
+        );
+        mangaItem.addEventListener(
+          'mouseleave',
+          event => (event.target.querySelector('p').innerText = titleTrimmed)
+        );
         tabContent.appendChild(mangaItem);
       });
     });

--- a/scripts/loadBackup.js
+++ b/scripts/loadBackup.js
@@ -39,7 +39,7 @@ export function handleFileLoad(event, fork = 'mihon') {
               initializeLibrary(); // Initialises Library with the Converter protobuf
               closeModal('load-modal'); // Closes the Load Modal
             } catch (error) {
-              alert('Error decoding protobuf file.');
+              alert(`Error decoding protobuf file.\n${error}`);
             }
           };
 

--- a/styles.css
+++ b/styles.css
@@ -94,6 +94,7 @@ body {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-around;
+  row-gap: 3em;
 }
 
 /* ---Manga Item--- */
@@ -117,9 +118,18 @@ body {
   width: 150px;
 }
 
-.manga-item p {
+.manga-item-title {
+  background: rgba(29, 29, 29, 0.84);
   font-size: 0.9em;
   margin-top: 10px;
+  max-height: 3.5em;
+  overflow: hidden;
+  position: absolute;
+  width: inherit;
+}
+.full-title {
+  max-height: unset;
+  overflow: unset;
 }
 
 /* ---Modals--- */


### PR DESCRIPTION
Trim titles displayed on the library view to keep spacing consistent. Full title on hover, both from the element `title` parameter and rewriting

| leave | hover |
|--------|--------|
| ![image](https://github.com/Animeboynz/Mihon-Backup-Viewer/assets/7104931/a979a427-3dae-4133-86c3-c80929e4b55d) | ![image](https://github.com/Animeboynz/Mihon-Backup-Viewer/assets/7104931/0ed6db25-160b-4825-b4dd-85a9c09ea05a) | 